### PR TITLE
delete service and customer delete by id

### DIFF
--- a/src/app/customer-list/customer-list.component.html
+++ b/src/app/customer-list/customer-list.component.html
@@ -62,7 +62,7 @@
           <ng-container matColumnDef="Delete">
             <th mat-header-cell *matHeaderCellDef mat-sort-header class = "action-td-th"> </th>
             <td mat-cell *matCellDef="let row" class = "action-td-th">
-              <button id='deleteCustomer' mat-stroked-button  color="warn" (click)='confirmDelete()'>
+              <button id='deleteCustomer' mat-stroked-button  color="warn" (click)='confirmDelete(row.id)'>
                 Delete </button>
             </td>
           </ng-container>

--- a/src/app/customer-list/customer-list.component.spec.ts
+++ b/src/app/customer-list/customer-list.component.spec.ts
@@ -224,7 +224,7 @@ describe('CustomerListComponent', () => {
     //let dialogRef = new MatDialogRef<ConfirmationDialogComponent>(OverlayRef.prototype,MatDialogContainer.prototype)
     //matDialog.disableClose=false
     spyOn(matDialog, 'open')//.and.callThrough()
-    component.confirmDelete()
+    component.confirmDelete(1)
     
     //fixture.detectChanges()
     expect(matDialog.open).toHaveBeenCalled();
@@ -244,12 +244,17 @@ describe('CustomerListComponent', () => {
     let dialogRefSpyObj = jasmine.createSpyObj({ afterClosed : of({}), close: null });
     dialogRefSpyObj.componentInstance = { body: '' }; // attach componentInstance to the spy object...
     dialogSpy = spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj);
-    component.confirmDelete()
+    let id = 1;
+    component.confirmDelete(id)
 
     expect(dialogSpy).toHaveBeenCalled();
     expect(dialogSpy).toHaveBeenCalledWith(ConfirmationDialogComponent,{ disableClose: false });
 
     expect(dialogRefSpyObj.afterClosed).toHaveBeenCalled();
+
+    serviceSpy = spyOn(customerService, 'delete').and.returnValue(of(new HttpResponse({body:null, status:200})))
+    spyOn(customerService, 'get').and.returnValue(of(httpResponse))
+    expect(component.deleteCustomer(id)).toHaveBeenCalled
   })
 
   it('confirmDelete() should open confirmation dialog with afterclose to be false',()=>{
@@ -257,7 +262,7 @@ describe('CustomerListComponent', () => {
     let dialogRefSpyObj = jasmine.createSpyObj({ afterClosed : of(false), close: null });
     dialogRefSpyObj.componentInstance = { body: '' }; // attach componentInstance to the spy object...
     dialogSpy = spyOn(TestBed.inject(MatDialog), 'open').and.returnValue(dialogRefSpyObj);
-    component.confirmDelete()
+    component.confirmDelete(1)
 
     expect(dialogSpy).toHaveBeenCalled();
     expect(dialogSpy).toHaveBeenCalledWith(ConfirmationDialogComponent,{ disableClose: false });
@@ -281,7 +286,7 @@ describe('CustomerListComponent', () => {
     //expect(deleteButtonEL).not.toBeNull()
     //deleteButtonEL.triggerEventHandler('click', null);
 
-    component.confirmDelete()
+    component.confirmDelete(1)
     //tick()
     fixture.detectChanges()
     //expect(matDialog.open).toHaveBeenCalled();
@@ -313,7 +318,7 @@ describe('CustomerListComponent', () => {
 
     //fixture.detectChanges()
     spyOn(matDialog, 'open')//.and.callThrough
-    component.confirmDelete()
+    component.confirmDelete(1)
     
     //fixture.detectChanges()
     expect(matDialog.open).toHaveBeenCalled();
@@ -327,4 +332,33 @@ describe('CustomerListComponent', () => {
     })*/
     //spyOn(matDialog, 'afterClose').and.callThrough()
   })
+
+  it('deleteCustomer() should call delete() in CustomerService and return status 200 with null body', fakeAsync(()=>{
+    
+    serviceSpy = spyOn(customerService, 'delete').and.returnValue(of(new HttpResponse({body:null, status:200})))
+    spyOn(customerService, 'get').and.returnValue(of(httpResponse))
+    component.deleteCustomer(1)
+    tick()
+    expect(serviceSpy.calls.any()).toBe(true);
+    
+    
+    expect(component.ngOnInit()).toHaveBeenCalled
+  }))
+
+  it('deleteCustomer() should call delete() in CustomerService and return status 304 with null body', fakeAsync(()=>{
+    
+    serviceSpy = spyOn(customerService, 'delete').and.returnValue(of(new HttpResponse({body:null, status:304, statusText:'Not Modified'})))
+    spyOn(customerService, 'get').and.returnValue(of(httpResponse))
+    component.deleteCustomer(1)
+    tick()
+    expect(serviceSpy.calls.any()).toBe(true);
+  }))
+
+  it('deleteCustomer() should throw error on http status 500', fakeAsync(()=>{
+   
+    serviceSpy = spyOn(customerService, 'delete').and.returnValue(throwError({status: 500}))
+    component.deleteCustomer(1)
+    tick()
+    expect(serviceSpy.calls.any()).toBe(true);
+  }))
 });

--- a/src/app/customer-list/customer-list.component.ts
+++ b/src/app/customer-list/customer-list.component.ts
@@ -85,7 +85,8 @@ export class CustomerListComponent implements OnInit, AfterViewInit {
     });
   }
 
-  confirmDelete() {
+  confirmDelete(id:number) {
+    //console.log(id)
     let dialogRef = this.dialog.open(ConfirmationDialogComponent, {
       disableClose: false
 
@@ -97,12 +98,30 @@ export class CustomerListComponent implements OnInit, AfterViewInit {
       if(result) {
         //console.log(result)
         // do confirmation actions
-        
+        this.deleteCustomer(id)
         //console.log(dialogRef)
         //console.log('Deleted')
       }
       //dialogRef = null;
     });
+  }
+
+  deleteCustomer(id:number){
+    this.loading=true
+    this.customerService.delete(id).subscribe(response=>{
+      this.loading=false
+      //console.log('called customerService')
+      if(response.status==200){
+        this.ngOnInit()
+      }
+      else{
+        //show snack bar
+        this.openSnackBar(response.statusText)
+      }
+    },(err)=>{
+      this.loading=false;
+      this.openSnackBar(`${ResponseDescription.FailedResponse}`)
+    })
   }
 
   ngOnInit(): void {

--- a/src/app/services/customer.service.spec.ts
+++ b/src/app/services/customer.service.spec.ts
@@ -108,4 +108,34 @@ describe('CustomerService', () => {
       expect(req.request.method).toEqual('POST');
       req.flush(null, { status: 400, statusText: 'Bad Request' });
   })
+
+  it('delete() should retuen status code 200 and an empty response body', ()=>{
+    let id=1;
+    service.delete(id).subscribe((response) => {
+      expect(response.status).toBe(200)
+      let responseBody = response.body==null?null:response.body;
+      expect(responseBody).toBeNull()
+      
+      });
+
+      const req = httpTestingController.expectOne(`${GlobalConstants.customerBaseAPIUrl}/${id}`);
+      
+      expect(req.request.method).toEqual('DELETE');
+      req.flush(null, { status: 200, statusText: 'Ok' });
+  })
+
+  it('delete() should retuen status code 204 and an empty response body', ()=>{
+    let id=1;
+    service.delete(id).subscribe((response) => {
+      expect(response.status).toBe(204)
+      let responseBody = response.body==null?null:response.body;
+      expect(responseBody).toBeNull()
+      
+      });
+
+      const req = httpTestingController.expectOne(`${GlobalConstants.customerBaseAPIUrl}/${id}`);
+      
+      expect(req.request.method).toEqual('DELETE');
+      req.flush(null, { status: 204, statusText: 'Not Found' });
+  })
 });

--- a/src/app/services/customer.service.ts
+++ b/src/app/services/customer.service.ts
@@ -22,4 +22,9 @@ export class CustomerService {
     return this.http.post<Customer>(url, customer,{observe: 'response' })
   }
 
+  delete(id:number):Observable<HttpResponse<any>>{
+    let url = `${GlobalConstants.customerBaseAPIUrl}/${id}`;
+    return this.http.delete<Customer>(url,{observe: 'response' })
+  }
+
 }


### PR DESCRIPTION
added delete service and customer delete by id in customer list component after close (true) of dialog
updated customer list html to pass id of customer object to be deleted
added customer list refresh functionality
added full unit test for the above use cases